### PR TITLE
Add shipper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+FROM ghcr.io/neosperience/shipper:0.3 as shipper
 FROM argoproj/argocd:latest
 # TODO: use a smaller base image and install just the argocd cli but you need to fix this error before
 # time="2021-03-19T12:19:34Z" level=fatal msg="rpc error: code = Internal desc = transport: received the unexpected content-type \"text/plain; charset=utf-8\"
@@ -12,4 +13,5 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
 
+COPY --from=shipper /usr/local/bin/shipper /usr/local/bin/shipper
 USER argocd


### PR DESCRIPTION
This PR adds [Shipper](https://github.com/neosperience/shipper) as an available tool. This is useful for CD pipelines that need to first update the target GitOps repo with the new image tag, then wait for ArgoCD to finish deploying the new tag.

 e.g.
 
 ```sh
shipper # bunch of flags to update the repository 
argocd app sync --prune $ARGOCD_APP
argocd app wait $ARGOCD_APP
```